### PR TITLE
fix: normalize slices in transform.go to nil slices instead of empty

### DIFF
--- a/plugin/transform.go
+++ b/plugin/transform.go
@@ -47,12 +47,12 @@ func PolicyToProto(p policy.Policy) *proto.PolicyRequest {
 
 // Transform protobuf PolicyRequest into a pluign Policy
 func NewPolicyFromProto(pb *proto.PolicyRequest) policy.Policy {
-	p := policy.Policy{}
+	var p policy.Policy
 
 	for _, r := range pb.Rule {
-		var parameter extensions.Parameter
+		var parameter *extensions.Parameter
 		if r.Parameter != nil {
-			parameter = extensions.Parameter{
+			parameter = &extensions.Parameter{
 				ID:          r.Parameter.Name,
 				Description: r.Parameter.Description,
 				Value:       r.Parameter.SelectedValue,
@@ -72,7 +72,7 @@ func NewPolicyFromProto(pb *proto.PolicyRequest) policy.Policy {
 			Rule: extensions.Rule{
 				ID:          r.Name,
 				Description: r.Description,
-				Parameter:   &parameter,
+				Parameter:   parameter,
 			},
 			Checks: checks,
 		}
@@ -99,10 +99,7 @@ var resultByProto = map[proto.Result]policy.Result{
 }
 
 func NewResultFromProto(pb *proto.PVPResult) policy.PVPResult {
-	result := policy.PVPResult{
-		ObservationsByCheck: make([]policy.ObservationByCheck, 0),
-		Links:               make([]policy.Link, 0),
-	}
+	result := policy.PVPResult{}
 
 	for _, o := range pb.Observations {
 		observation := policy.ObservationByCheck{
@@ -112,14 +109,14 @@ func NewResultFromProto(pb *proto.PVPResult) policy.PVPResult {
 			Collected:   o.CollectedAt.AsTime(),
 			CheckID:     o.CheckId,
 		}
-		links := make([]policy.Link, 0)
+		var links []policy.Link
 		for _, ref := range o.EvidenceRefs {
 			link := policy.Link{Description: ref.Description, Href: ref.Href}
 			links = append(links, link)
 		}
 		observation.RelevantEvidences = links
 
-		subjects := make([]policy.Subject, 0)
+		var subjects []policy.Subject
 		for _, s := range o.Subjects {
 			subject := policy.Subject{
 				Title:       s.Title,
@@ -129,7 +126,7 @@ func NewResultFromProto(pb *proto.PVPResult) policy.PVPResult {
 				EvaluatedOn: s.EvaluatedOn.AsTime(),
 				Reason:      s.Reason,
 			}
-			subjectProps := make([]policy.Property, 0)
+			var subjectProps []policy.Property
 			for _, sp := range s.Props {
 				subjectProp := policy.Property{Name: sp.Name, Value: sp.Value}
 				subjectProps = append(subjectProps, subjectProp)
@@ -139,7 +136,7 @@ func NewResultFromProto(pb *proto.PVPResult) policy.PVPResult {
 		}
 		observation.Subjects = subjects
 
-		props := make([]policy.Property, 0)
+		var props []policy.Property
 		for _, p := range o.Props {
 			prop := policy.Property{Name: p.Name, Value: p.Value}
 			props = append(props, prop)
@@ -155,10 +152,10 @@ func NewResultFromProto(pb *proto.PVPResult) policy.PVPResult {
 	return result
 }
 
-func ResultsToProto(p policy.PVPResult) *proto.PVPResult {
-	pvpResult := &proto.PVPResult{Observations: make([]*proto.ObservationByCheck, 0)}
+func ResultsToProto(result policy.PVPResult) *proto.PVPResult {
+	pvpResult := &proto.PVPResult{}
 
-	for _, o := range p.ObservationsByCheck {
+	for _, o := range result.ObservationsByCheck {
 		observation := &proto.ObservationByCheck{
 			Name:        o.Title,
 			Description: o.Description,
@@ -166,7 +163,7 @@ func ResultsToProto(p policy.PVPResult) *proto.PVPResult {
 			Methods:     o.Methods,
 			CollectedAt: timestamppb.New(o.Collected),
 		}
-		subjects := make([]*proto.Subject, 0)
+		var subjects []*proto.Subject
 		for _, s := range o.Subjects {
 			subject := &proto.Subject{
 				Title:       s.Title,
@@ -176,7 +173,7 @@ func ResultsToProto(p policy.PVPResult) *proto.PVPResult {
 				EvaluatedOn: timestamppb.New(s.EvaluatedOn),
 				Reason:      s.Reason,
 			}
-			subjectProps := make([]*proto.Property, 0)
+			var subjectProps []*proto.Property
 			for _, sp := range s.Props {
 				subjectProp := &proto.Property{Name: sp.Name, Value: sp.Value}
 				subjectProps = append(subjectProps, subjectProp)
@@ -184,12 +181,12 @@ func ResultsToProto(p policy.PVPResult) *proto.PVPResult {
 			subject.Props = subjectProps
 			subjects = append(subjects, subject)
 		}
-		evidences := make([]*proto.Link, 0)
+		var evidences []*proto.Link
 		for _, evidence := range o.RelevantEvidences {
 			link := &proto.Link{Description: evidence.Description, Href: evidence.Href}
 			evidences = append(evidences, link)
 		}
-		props := make([]*proto.Property, 0)
+		var props []*proto.Property
 		for _, p := range o.Props {
 			prop := &proto.Property{Name: p.Name, Value: p.Value}
 			props = append(props, prop)
@@ -200,7 +197,7 @@ func ResultsToProto(p policy.PVPResult) *proto.PVPResult {
 		pvpResult.Observations = append(pvpResult.Observations, observation)
 	}
 
-	for _, l := range p.Links {
+	for _, l := range result.Links {
 		link := &proto.Link{
 			Description: l.Description,
 			Href:        l.Href,

--- a/plugin/transform_test.go
+++ b/plugin/transform_test.go
@@ -6,15 +6,15 @@
 package plugin
 
 import (
+	"testing"
 	"time"
 
-	"github.com/oscal-compass/compliance-to-policy-go/v2/api/proto"
-	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"testing"
+	"github.com/oscal-compass/compliance-to-policy-go/v2/api/proto"
+	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 )
 
 var testTimeString, _ = time.Parse("00:00:00", "12:00:00")


### PR DESCRIPTION
There is a chance many of the slices in the transformation will not be populated. Using a nil slices does not allocate the underlying array when it is not needed.